### PR TITLE
Fixes yii2 minimal version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "yiisoft/yii2": "^2"
+    "yiisoft/yii2": "~2.0.13"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Fixes composer.json because class yii\base\BaseObject not exist in yiisoft/yii2 < 2.0.13.
This is patch for versions since 4.1 (for example, must be released as 4.1.1).